### PR TITLE
Update formula to fix gsub deprecation

### DIFF
--- a/Formula/qtifw.rb
+++ b/Formula/qtifw.rb
@@ -34,8 +34,8 @@ class Qtifw < Formula
 
   def inreplace_qt_ifw_pro(file_path)
     inreplace file_path do |s|
-      s.gsub!("$$[QT_INSTALL_LIBS]", "$${PREFIX}/lib", false)
-      s.gsub!("$$[QT_INSTALL_BINS]", "$${PREFIX}/bin", false)
+      s.gsub!("$$[QT_INSTALL_LIBS]", "$${PREFIX}/lib", audit_result: false)
+      s.gsub!("$$[QT_INSTALL_BINS]", "$${PREFIX}/bin", audit_result: false)
     end
   end
 


### PR DESCRIPTION
This is a simple update to fix homebrew warning when installing qtifw.  It mentions that calling gsub!(before, after, false) is deprecated.

<img width="1077" height="149" alt="Screenshot 2025-07-31 at 1 59 07 PM" src="https://github.com/user-attachments/assets/dfaa5dc7-a35f-453b-9705-d4936affc073" />

---

- [ ] Have you followed the guidelines in our [Contributing](https://github.com/jmuelbert/homebrew-qtifw/blob/master/CONTRIBUTING.md) document?
- [ ] Have you checked to ensure there aren't other open [Pull Requests](https://github.com/jmuelbert/homebrew-qtifw/pulls) for the same change?
- [ ] Have you added an explanation of what your changes do and why you'd like us to include them?
- [ ] Have you written new tests for your changes? [Here's an introduction](https://help.github.com/articles/creating-a-pull-request/).
- [ ] Have you successfully run `brew tests` with your changes locally?

---
